### PR TITLE
Fix translation fallback expression in VerseCycler

### DIFF
--- a/components/poetry/VerseCycler.tsx
+++ b/components/poetry/VerseCycler.tsx
@@ -39,7 +39,10 @@ export function VerseCycler() {
           <VerseBlock
             urdu={current.lang === 'ur' ? current.text : undefined}
             transliteration={current.transliteration}
-            translation={current.translation if current.translation else (current.lang === 'en' ? current.text : undefined)}
+            translation={
+              current.translation ??
+              (current.lang === 'en' ? current.text : undefined)
+            }
             showTransliteration={showTransliteration}
             showTranslation={showTranslation}
           />


### PR DESCRIPTION
## Summary
- replace the invalid translation prop expression in `VerseCycler` with a nullish-coalescing fallback so English verses still display

## Testing
- pnpm lint *(fails: command prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cb027f6e848332bd4b9bf1f30864f8