### PR TITLE
Handle visibility change listener cleanup

### DIFF
--- a/components/canvas/WeightlessParticles.tsx
+++ b/components/canvas/WeightlessParticles.tsx
@@ -49,11 +49,16 @@ export function WeightlessParticles({ dimmed = false }: Props) {
     resize();
     step();
     window.addEventListener('resize', resize);
-    document.addEventListener('visibilitychange', () => {
+    function handleVisibilityChange() {
       if (document.hidden) cancelAnimationFrame(raf);
       else raf = requestAnimationFrame(step);
-    });
-    return () => { cancelAnimationFrame(raf); window.removeEventListener('resize', resize); };
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [dimmed, density, energy]);
 
   return <canvas ref={canvasRef} className="pointer-events-none absolute inset-0 -z-10" />;


### PR DESCRIPTION
## Summary
- extract the visibility change listener into a named function so it can be reused
- clean up both resize and visibilitychange listeners when the component unmounts while keeping the animation pause/resume logic

## Testing
- ⚠️ `pnpm lint` *(fails: command requires interactive ESLint setup and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0284e1e08332ad684b7c398413cb