### PR TITLE
Implement audio graph and scene store integration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/experience/page.tsx
+++ b/app/experience/page.tsx
@@ -4,6 +4,7 @@ import { EarthWindow } from '@/components/video/EarthWindow';
 import { WeightlessParticles } from '@/components/canvas/WeightlessParticles';
 import { VerseCycler } from '@/components/poetry/VerseCycler';
 import { ControlsBar } from '@/components/ui/ControlsBar';
+import { AudioEnergyProvider } from '@/components/providers/AudioEnergyProvider';
 import { useSceneStore } from '@/lib/scene';
 
 export default function ExperiencePage() {
@@ -19,6 +20,7 @@ export default function ExperiencePage() {
 
   return (
     <main className="relative min-h-dvh w-full overflow-hidden bg-black">
+      <AudioEnergyProvider />
       <EarthWindow />
       <WeightlessParticles dimmed={focusMode} />
       <div className="pointer-events-none absolute inset-0 grid place-items-center p-6 video-gradient">

--- a/components/poetry/VerseCycler.tsx
+++ b/components/poetry/VerseCycler.tsx
@@ -39,7 +39,7 @@ export function VerseCycler() {
           <VerseBlock
             urdu={current.lang === 'ur' ? current.text : undefined}
             transliteration={current.transliteration}
-            translation={current.translation if current.translation else (current.lang === 'en' ? current.text : undefined)}
+            translation={current.translation ?? (current.lang === 'en' ? current.text : undefined)}
             showTransliteration={showTransliteration}
             showTranslation={showTranslation}
           />

--- a/components/providers/AudioEnergyProvider.tsx
+++ b/components/providers/AudioEnergyProvider.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSceneStore } from '@/lib/scene';
+
+export function AudioEnergyProvider() {
+  const audioEnabled = useSceneStore(s => s.audio.enabled);
+  const sampleEnergy = useSceneStore(s => s.sampleAudioEnergy);
+
+  useEffect(() => {
+    let raf = 0;
+    const cancel = () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
+
+    if (!audioEnabled) {
+      sampleEnergy();
+      return cancel;
+    }
+
+    const tick = () => {
+      sampleEnergy();
+      raf = requestAnimationFrame(tick);
+    };
+
+    tick();
+
+    return cancel;
+  }, [audioEnabled, sampleEnergy]);
+
+  return null;
+}

--- a/lib/audio.ts
+++ b/lib/audio.ts
@@ -1,7 +1,101 @@
 'use client';
-let _enabled = false;
-let _volume = 0.6;
-export function initAudio() { _enabled = true; }
-export function setVolume(v: number) { _volume = Math.max(0, Math.min(1, v)); }
-export function isAudioEnabled() { return _enabled; }
-export function energy() { return 0; } // replace with AnalyserNode RMS later
+
+let audioContext: AudioContext | null = null;
+let audioElement: HTMLAudioElement | null = null;
+let sourceNode: MediaElementAudioSourceNode | null = null;
+let gainNode: GainNode | null = null;
+let analyserNode: AnalyserNode | null = null;
+let timeDomainData: Float32Array | null = null;
+let graphInitialized = false;
+let desiredVolume = 0.6;
+
+function ensureContext() {
+  if (typeof window === 'undefined') return null;
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+
+function ensureAudioElement() {
+  if (typeof window === 'undefined') return null;
+  if (!audioElement) {
+    audioElement = document.createElement('audio');
+    audioElement.setAttribute('data-role', 'earth-audio');
+    audioElement.crossOrigin = 'anonymous';
+    audioElement.loop = true;
+    audioElement.preload = 'auto';
+    audioElement.playsInline = true;
+    audioElement.style.display = 'none';
+    document.body.appendChild(audioElement);
+  }
+  return audioElement;
+}
+
+function initGraph() {
+  const ctx = ensureContext();
+  const element = ensureAudioElement();
+  if (!ctx || !element) return null;
+  if (!graphInitialized) {
+    sourceNode = ctx.createMediaElementSource(element);
+    gainNode = ctx.createGain();
+    analyserNode = ctx.createAnalyser();
+    analyserNode.fftSize = 1024;
+    analyserNode.smoothingTimeConstant = 0.85;
+    sourceNode.connect(gainNode);
+    gainNode.connect(analyserNode);
+    analyserNode.connect(ctx.destination);
+    timeDomainData = new Float32Array(analyserNode.fftSize);
+    graphInitialized = true;
+  } else if (analyserNode && timeDomainData?.length !== analyserNode.fftSize) {
+    timeDomainData = new Float32Array(analyserNode.fftSize);
+  }
+  if (gainNode) {
+    gainNode.gain.value = desiredVolume;
+  }
+  return element;
+}
+
+export function initAudio() {
+  return initGraph();
+}
+
+export async function play() {
+  const element = initGraph();
+  const ctx = audioContext;
+  if (!element || !ctx) return;
+  try {
+    await ctx.resume();
+  } catch (err) {
+    // ignore resume errors (likely due to autoplay restrictions)
+  }
+  try {
+    if (element.paused) await element.play();
+  } catch (err) {
+    // Swallow play rejections so callers can decide how to react.
+  }
+}
+
+export function pause() {
+  if (!audioElement) return;
+  audioElement.pause();
+}
+
+export function setVolume(volume: number) {
+  desiredVolume = Math.max(0, Math.min(1, volume));
+  if (!gainNode) initGraph();
+  if (gainNode) {
+    gainNode.gain.value = desiredVolume;
+  }
+}
+
+export function getEnergy() {
+  if (!analyserNode || !timeDomainData) return 0;
+  analyserNode.getFloatTimeDomainData(timeDomainData);
+  let sumSquares = 0;
+  for (let i = 0; i < timeDomainData.length; i += 1) {
+    const sample = timeDomainData[i];
+    sumSquares += sample * sample;
+  }
+  return Math.sqrt(sumSquares / timeDomainData.length);
+}

--- a/lib/scene.ts
+++ b/lib/scene.ts
@@ -1,9 +1,17 @@
 'use client';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { initAudio as prepareAudioGraph, play as playGraph, pause as pauseGraph, setVolume as setGraphVolume, getEnergy as measureEnergy } from './audio';
 import type { Track } from './types';
 
 type Subtitles = { transliteration: boolean; translation: boolean };
+
+type AudioState = {
+  enabled: boolean;
+  volume: number;
+  muted: boolean;
+  energy: number;
+};
 
 type State = {
   track: Track;
@@ -12,12 +20,19 @@ type State = {
   verseIndex: number;
   verseIntervalMs: number;
   particleDensity: number;
+  audio: AudioState;
   energy: () => number;
   toggleTrack: () => void;
   toggleFocus: () => void;
   nextVerse: () => void;
   setSubtitles: (s: Subtitles) => void;
   setParticleDensity: (v: number) => void;
+  initAudio: () => HTMLAudioElement | null;
+  playAudio: () => Promise<void>;
+  pauseAudio: () => void;
+  setAudioVolume: (v: number) => void;
+  toggleAudioMute: () => void;
+  sampleAudioEnergy: () => void;
 };
 
 export const useSceneStore = create<State>()(persist((set, get) => ({
@@ -27,10 +42,51 @@ export const useSceneStore = create<State>()(persist((set, get) => ({
   verseIndex: 0,
   verseIntervalMs: Number(process.env.NEXT_PUBLIC_VERSE_INTERVAL_MS ?? 18000),
   particleDensity: Number(process.env.NEXT_PUBLIC_PARTICLE_DENSITY ?? 0.8),
-  energy: () => 0, // placeholder for audio-reactive energy
+  audio: { enabled: false, volume: 0.6, muted: false, energy: 0 },
+  energy: () => get().audio.energy,
   toggleTrack: () => set(s => ({ track: s.track === 'day' ? 'night' : 'day' })),
   toggleFocus: () => set(s => ({ focusMode: !s.focusMode })),
   nextVerse: () => set(s => ({ verseIndex: s.verseIndex + 1 })),
   setSubtitles: (subtitles) => set({ subtitles }),
   setParticleDensity: (v) => set({ particleDensity: v }),
+  initAudio: () => {
+    const element = prepareAudioGraph();
+    const { audio } = get();
+    setGraphVolume(audio.muted ? 0 : audio.volume);
+    return element;
+  },
+  playAudio: async () => {
+    const state = get();
+    prepareAudioGraph();
+    setGraphVolume(state.audio.muted ? 0 : state.audio.volume);
+    try {
+      await playGraph();
+      set(s => ({ audio: { ...s.audio, enabled: true } }));
+    } catch (err) {
+      // Playback might fail due to browser restrictions.
+    }
+  },
+  pauseAudio: () => {
+    pauseGraph();
+    set(s => ({ audio: { ...s.audio, enabled: false, energy: 0 } }));
+  },
+  setAudioVolume: (volume) => {
+    const clamped = Math.max(0, Math.min(1, volume));
+    const muted = get().audio.muted;
+    prepareAudioGraph();
+    setGraphVolume(muted ? 0 : clamped);
+    set(s => ({ audio: { ...s.audio, volume: clamped } }));
+  },
+  toggleAudioMute: () => {
+    prepareAudioGraph();
+    set(s => {
+      const muted = !s.audio.muted;
+      setGraphVolume(muted ? 0 : s.audio.volume);
+      return { audio: { ...s.audio, muted } };
+    });
+  },
+  sampleAudioEnergy: () => {
+    const energy = measureEnergy();
+    set(s => ({ audio: { ...s.audio, energy } }));
+  },
 }), { name: 'earth-ghazal' }));


### PR DESCRIPTION
## Summary
- build a reusable Web Audio graph in `lib/audio.ts` and expose helpers for playback, volume and analyser energy
- extend the scene store with persisted audio state/actions and wire an `AudioEnergyProvider` to keep energy reactive in the experience page
- add an ESLint config and tidy the verse translation expression so project linting succeeds

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb052259188332b7de163dc8e86709