### PR TITLE
Add audio initialization overlay and controls

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+.DS_Store
+pnpm-debug.log*

--- a/app/experience/page.tsx
+++ b/app/experience/page.tsx
@@ -4,14 +4,17 @@ import { EarthWindow } from '@/components/video/EarthWindow';
 import { WeightlessParticles } from '@/components/canvas/WeightlessParticles';
 import { VerseCycler } from '@/components/poetry/VerseCycler';
 import { ControlsBar } from '@/components/ui/ControlsBar';
+import { IntroOverlay } from '@/components/ui/IntroOverlay';
 import { useSceneStore } from '@/lib/scene';
 
 export default function ExperiencePage() {
   const focusMode = useSceneStore(s => s.focusMode);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.code === 'KeyF') useSceneStore.getState().toggleFocus();
-      if (e.code === 'KeyT') useSceneStore.getState().toggleTrack();
+      const state = useSceneStore.getState();
+      if (!state.audioReady) return;
+      if (e.code === 'KeyF') state.toggleFocus();
+      if (e.code === 'KeyT') state.toggleTrack();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -20,6 +23,7 @@ export default function ExperiencePage() {
   return (
     <main className="relative min-h-dvh w-full overflow-hidden bg-black">
       <EarthWindow />
+      <IntroOverlay />
       <WeightlessParticles dimmed={focusMode} />
       <div className="pointer-events-none absolute inset-0 grid place-items-center p-6 video-gradient">
         <Suspense fallback={null}>

--- a/components/poetry/VerseCycler.tsx
+++ b/components/poetry/VerseCycler.tsx
@@ -39,7 +39,7 @@ export function VerseCycler() {
           <VerseBlock
             urdu={current.lang === 'ur' ? current.text : undefined}
             transliteration={current.transliteration}
-            translation={current.translation if current.translation else (current.lang === 'en' ? current.text : undefined)}
+            translation={current.translation ?? (current.lang === 'en' ? current.text : undefined)}
             showTransliteration={showTransliteration}
             showTranslation={showTranslation}
           />

--- a/components/ui/ControlsBar.tsx
+++ b/components/ui/ControlsBar.tsx
@@ -6,6 +6,14 @@ export function ControlsBar() {
   const toggleFocus = useSceneStore(s => s.toggleFocus);
   const track = useSceneStore(s => s.track);
   const toggleTrack = useSceneStore(s => s.toggleTrack);
+  const audioReady = useSceneStore(s => s.audioReady);
+  const audioPlaying = useSceneStore(s => s.audioPlaying);
+  const playAudio = useSceneStore(s => s.playAudio);
+  const pauseAudio = useSceneStore(s => s.pauseAudio);
+  const audioMuted = useSceneStore(s => s.audioMuted);
+  const toggleMute = useSceneStore(s => s.toggleMute);
+  const audioVolume = useSceneStore(s => s.audioVolume);
+  const setAudioVolume = useSceneStore(s => s.setAudioVolume);
   const subtitles = useSceneStore(s => s.subtitles);
   const setSubtitles = useSceneStore(s => s.setSubtitles);
   const particleDensity = useSceneStore(s => s.particleDensity);
@@ -15,10 +23,43 @@ export function ControlsBar() {
     <div className="pointer-events-auto fixed inset-x-0 bottom-0 z-10 px-4 pb-4">
       <div className="mx-auto w-full max-w-5xl rounded-2xl bg-black/40 backdrop-blur border border-white/10">
         <div className="flex flex-wrap items-center gap-4 p-3 text-sm">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={audioPlaying ? pauseAudio : playAudio}
+              disabled={!audioReady}
+              className="rounded-xl border border-white/15 px-3 py-2 hover:bg-white/5 disabled:opacity-40 disabled:hover:bg-transparent disabled:cursor-not-allowed"
+            >
+              {audioPlaying ? 'Pause' : 'Play'}
+            </button>
+            <button
+              onClick={toggleMute}
+              disabled={!audioReady}
+              className="rounded-xl border border-white/15 px-3 py-2 hover:bg-white/5 disabled:opacity-40 disabled:hover:bg-transparent disabled:cursor-not-allowed"
+            >
+              {audioMuted ? 'Unmute' : 'Mute'}
+            </button>
+          </div>
+          <label className="flex items-center gap-2 whitespace-nowrap">
+            Volume
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={audioVolume}
+              onChange={e => setAudioVolume(parseFloat(e.target.value))}
+              disabled={!audioReady}
+              className="w-28 accent-white/90 disabled:opacity-40"
+            />
+          </label>
           <button onClick={toggleFocus} className="rounded-xl border border-white/15 px-3 py-2 hover:bg-white/5">
             {focus ? 'Exit Focus' : 'Focus Mode'}
           </button>
-          <button onClick={toggleTrack} className="rounded-xl border border-white/15 px-3 py-2 hover:bg-white/5">
+          <button
+            onClick={toggleTrack}
+            disabled={!audioReady}
+            className="rounded-xl border border-white/15 px-3 py-2 hover:bg-white/5 disabled:opacity-40 disabled:hover:bg-transparent disabled:cursor-not-allowed"
+          >
             {track === 'day' ? 'Night' : 'Day'}
           </button>
           <label className="flex items-center gap-2">

--- a/components/ui/IntroOverlay.tsx
+++ b/components/ui/IntroOverlay.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useSceneStore } from '@/lib/scene';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button',
+  'textarea',
+  'input',
+  'select',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function IntroOverlay() {
+  const audioReady = useSceneStore(s => s.audioReady);
+  const initAudio = useSceneStore(s => s.initAudio);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (audioReady) {
+      previouslyFocused.current?.focus?.();
+      previouslyFocused.current = null;
+      return;
+    }
+
+    const node = overlayRef.current;
+    if (!node) return;
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+
+    const focusable = Array.from(
+      node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+    ).filter(el => !el.hasAttribute('disabled'));
+
+    (focusable[0] ?? node).focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      const active = document.activeElement as HTMLElement | null;
+      const currentFocusable = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+      ).filter(el => !el.hasAttribute('disabled'));
+      if (!currentFocusable.length) return;
+      const first = currentFocusable[0];
+      const last = currentFocusable[currentFocusable.length - 1];
+
+      if (event.shiftKey) {
+        if (!active || active === first || !node.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (!active || active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [audioReady]);
+
+  if (audioReady) {
+    return null;
+  }
+
+  const handleStart = () => {
+    initAudio();
+  };
+
+  return (
+    <div className="pointer-events-auto absolute inset-0 z-20 flex items-center justify-center bg-black/80 backdrop-blur-sm px-6 py-10">
+      <div
+        ref={overlayRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="intro-heading"
+        aria-describedby="intro-description"
+        tabIndex={-1}
+        className="w-full max-w-xl rounded-3xl border border-white/10 bg-black/75 p-8 text-center shadow-2xl"
+      >
+        <h1 id="intro-heading" className="text-2xl font-semibold tracking-wide text-white">
+          Experience Earth Ghazal with sound
+        </h1>
+        <p id="intro-description" className="mt-4 text-sm text-white/80 leading-relaxed">
+          For the full immersion, enable audio and let the verses flow with the visuals. We&apos;ll remember your
+          choice for next time.
+        </p>
+        <div className="mt-6 space-y-3 text-left text-xs text-white/60">
+          <p className="font-medium text-white/80">While you listen:</p>
+          <ul className="list-disc space-y-1 pl-5">
+            <li>Press <kbd className="rounded bg-white/10 px-1">F</kbd> to toggle focus mode.</li>
+            <li>Press <kbd className="rounded bg-white/10 px-1">T</kbd> to switch between day and night once audio begins.</li>
+            <li>Use the controls below to adjust subtitles, visuals, and volume.</li>
+          </ul>
+        </div>
+        <button
+          type="button"
+          onClick={handleStart}
+          className="mt-8 inline-flex w-full justify-center rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-sm font-semibold tracking-wide text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+        >
+          Start with sound
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/audio.ts
+++ b/lib/audio.ts
@@ -1,7 +1,45 @@
 'use client';
 let _enabled = false;
+let _playing = false;
+let _muted = false;
 let _volume = 0.6;
-export function initAudio() { _enabled = true; }
-export function setVolume(v: number) { _volume = Math.max(0, Math.min(1, v)); }
-export function isAudioEnabled() { return _enabled; }
+
+export function initAudio() {
+  _enabled = true;
+  _playing = true;
+}
+
+export function play() {
+  if (!_enabled) initAudio();
+  _playing = true;
+}
+
+export function pause() {
+  _playing = false;
+}
+
+export function setMuted(value: boolean) {
+  _muted = value;
+}
+
+export function isMuted() {
+  return _muted;
+}
+
+export function isPlaying() {
+  return _playing;
+}
+
+export function setVolume(v: number) {
+  _volume = Math.max(0, Math.min(1, v));
+}
+
+export function getVolume() {
+  return _volume;
+}
+
+export function isAudioEnabled() {
+  return _enabled;
+}
+
 export function energy() { return 0; } // replace with AnalyserNode RMS later

--- a/lib/scene.ts
+++ b/lib/scene.ts
@@ -2,6 +2,15 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { Track } from './types';
+import {
+  energy as audioEnergy,
+  initAudio as initAudioEngine,
+  pause as pauseAudioEngine,
+  play as playAudioEngine,
+  setMuted as setAudioMuted,
+  setVolume as setAudioVolumeEngine,
+  getVolume as getAudioVolume,
+} from './audio';
 
 type Subtitles = { transliteration: boolean; translation: boolean };
 
@@ -12,12 +21,21 @@ type State = {
   verseIndex: number;
   verseIntervalMs: number;
   particleDensity: number;
+  audioReady: boolean;
+  audioPlaying: boolean;
+  audioMuted: boolean;
+  audioVolume: number;
   energy: () => number;
   toggleTrack: () => void;
   toggleFocus: () => void;
   nextVerse: () => void;
   setSubtitles: (s: Subtitles) => void;
   setParticleDensity: (v: number) => void;
+  initAudio: () => void;
+  playAudio: () => void;
+  pauseAudio: () => void;
+  toggleMute: () => void;
+  setAudioVolume: (v: number) => void;
 };
 
 export const useSceneStore = create<State>()(persist((set, get) => ({
@@ -27,10 +45,63 @@ export const useSceneStore = create<State>()(persist((set, get) => ({
   verseIndex: 0,
   verseIntervalMs: Number(process.env.NEXT_PUBLIC_VERSE_INTERVAL_MS ?? 18000),
   particleDensity: Number(process.env.NEXT_PUBLIC_PARTICLE_DENSITY ?? 0.8),
-  energy: () => 0, // placeholder for audio-reactive energy
-  toggleTrack: () => set(s => ({ track: s.track === 'day' ? 'night' : 'day' })),
+  audioReady: false,
+  audioPlaying: false,
+  audioMuted: false,
+  audioVolume: getAudioVolume(),
+  energy: () => audioEnergy(), // placeholder for audio-reactive energy
+  toggleTrack: () => set(s => (s.audioReady ? { track: s.track === 'day' ? 'night' : 'day' } : {})),
   toggleFocus: () => set(s => ({ focusMode: !s.focusMode })),
   nextVerse: () => set(s => ({ verseIndex: s.verseIndex + 1 })),
   setSubtitles: (subtitles) => set({ subtitles }),
   setParticleDensity: (v) => set({ particleDensity: v }),
+  initAudio: () => {
+    if (get().audioReady) {
+      playAudioEngine();
+      set({ audioPlaying: true });
+      return;
+    }
+    initAudioEngine();
+    const { audioMuted, audioVolume } = get();
+    setAudioVolumeEngine(audioVolume);
+    setAudioMuted(audioMuted);
+    playAudioEngine();
+    set({ audioReady: true, audioPlaying: true });
+  },
+  playAudio: () => {
+    if (!get().audioReady) return;
+    playAudioEngine();
+    set({ audioPlaying: true });
+  },
+  pauseAudio: () => {
+    if (!get().audioReady) return;
+    pauseAudioEngine();
+    set({ audioPlaying: false });
+  },
+  toggleMute: () => {
+    if (!get().audioReady) return;
+    set(state => {
+      const nextMuted = !state.audioMuted;
+      setAudioMuted(nextMuted);
+      return { audioMuted: nextMuted };
+    });
+  },
+  setAudioVolume: (value: number) => {
+    set(state => {
+      const clamped = Math.max(0, Math.min(1, value));
+      setAudioVolumeEngine(clamped);
+      if (state.audioReady && state.audioMuted && clamped > 0) {
+        setAudioMuted(false);
+        return { audioVolume: clamped, audioMuted: false };
+      }
+      if (state.audioReady) {
+        setAudioMuted(clamped === 0 ? true : state.audioMuted);
+        return {
+          audioVolume: clamped,
+          audioMuted: clamped === 0 ? true : state.audioMuted,
+        };
+      }
+      return { audioVolume: clamped };
+    });
+  },
 }), { name: 'earth-ghazal' }));


### PR DESCRIPTION
## Summary
- add an introductory overlay that requests starting the experience with sound and hides itself after initializing audio
- expand the scene store and audio helpers to track playback/mute/volume state and wire the controls bar to play, pause, mute, and disable track switching until audio is ready
- document linting defaults and correct the verse translation binding so linting can run cleanly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb05255d74833291bc57d75908ad7b