### PR TITLE
Enhance media manifests and playback controls

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/app/api/playlist/route.ts
+++ b/app/api/playlist/route.ts
@@ -1,15 +1,191 @@
-import { NextResponse } from 'next/server';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { NextRequest, NextResponse } from 'next/server';
+import type { MediaSource, PlaylistManifest, Track, TrackManifest } from '@/lib/types';
 
-export async function GET() {
-  const width = 1920; // could parse User-Agent-Client-Hints to pick 1080/2160
-  const mp4 = width >= 2000 ? '2160' : '1080';
-  return NextResponse.json({
-    track: 'day',
-    srcs: [
-      { type: 'mp4', url: `/video/earth_day_${mp4}.mp4` },
-      { type: 'webm', url: `/video/earth_day.webm` }
-    ],
+const PUBLIC_DIR = path.join(process.cwd(), 'public');
+
+const TRACK_LIBRARY: TrackManifest[] = [
+  {
+    id: 'day',
+    label: 'Daybreak Orbit',
     poster: '/images/poster_day.jpg',
-    loop: true
+    loop: true,
+    video: [
+      {
+        url: '/video/earth_day_2160.mp4',
+        type: 'video/mp4',
+        codec: 'hvc1.2.4.L150.90',
+        width: 3840,
+        height: 2160,
+        bitrate: 16000000,
+      },
+      {
+        url: '/video/earth_day_1080.mp4',
+        type: 'video/mp4',
+        codec: 'avc1.640028',
+        width: 1920,
+        height: 1080,
+        bitrate: 8000000,
+      },
+      {
+        url: '/video/earth_day_1080.mp4#720p',
+        type: 'video/mp4',
+        codec: 'avc1.64001f',
+        width: 1280,
+        height: 720,
+        bitrate: 4500000,
+      },
+      {
+        url: '/video/earth_day.webm',
+        type: 'video/webm',
+        codec: 'vp9',
+        width: 1920,
+        height: 1080,
+        bitrate: 6000000,
+      },
+    ],
+    audio: [
+      { url: '/audio/earth_day.webm', type: 'audio/webm', codec: 'opus', bitrate: 256000 },
+      { url: '/audio/earth_day.mp3', type: 'audio/mpeg', bitrate: 256000 },
+    ],
+  },
+  {
+    id: 'night',
+    label: 'Nocturne Orbit',
+    poster: '/images/poster_night.jpg',
+    loop: true,
+    video: [
+      {
+        url: '/video/earth_night_2160.mp4',
+        type: 'video/mp4',
+        codec: 'hvc1.2.4.L150.90',
+        width: 3840,
+        height: 2160,
+        bitrate: 16000000,
+      },
+      {
+        url: '/video/earth_night_1080.mp4',
+        type: 'video/mp4',
+        codec: 'avc1.640028',
+        width: 1920,
+        height: 1080,
+        bitrate: 8000000,
+      },
+      {
+        url: '/video/earth_night_1080.mp4#720p',
+        type: 'video/mp4',
+        codec: 'avc1.64001f',
+        width: 1280,
+        height: 720,
+        bitrate: 4500000,
+      },
+      {
+        url: '/video/earth_night.webm',
+        type: 'video/webm',
+        codec: 'vp9',
+        width: 1920,
+        height: 1080,
+        bitrate: 6000000,
+      },
+    ],
+    audio: [
+      { url: '/audio/earth_night.webm', type: 'audio/webm', codec: 'opus', bitrate: 256000 },
+      { url: '/audio/earth_night.mp3', type: 'audio/mpeg', bitrate: 256000 },
+    ],
+  },
+];
+
+const cleanUrl = (url: string) => {
+  const [pathPart] = url.split('?');
+  const [withoutHash] = pathPart.split('#');
+  return withoutHash;
+};
+
+const sourceExists = (source: MediaSource) => {
+  const url = cleanUrl(source.url);
+  if (!url.startsWith('/')) return false;
+  return existsSync(path.join(PUBLIC_DIR, url));
+};
+
+const filterExistingSources = (sources: MediaSource[]): MediaSource[] => {
+  return sources.filter(sourceExists);
+};
+
+const parseNumberHeader = (value: string | null): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const deriveTargetWidth = (request: NextRequest) => {
+  const reportedWidth = parseNumberHeader(request.headers.get('sec-ch-width'));
+  const viewportWidth = parseNumberHeader(request.headers.get('viewport-width'));
+  const dpr = parseNumberHeader(request.headers.get('sec-ch-dpr')) ?? 1;
+  const width = reportedWidth ?? viewportWidth;
+  return (width ?? 1920) * dpr;
+};
+
+const prefersLowBandwidth = (request: NextRequest) => {
+  const saveData = request.headers.get('save-data') ?? request.headers.get('sec-ch-save-data');
+  return saveData?.toLowerCase() === 'on';
+};
+
+const sortVariants = (
+  variants: MediaSource[],
+  targetWidth: number,
+  prioritizeEfficiency: boolean,
+): MediaSource[] => {
+  return [...variants].sort((a, b) => {
+    const widthA = a.width ?? targetWidth;
+    const widthB = b.width ?? targetWidth;
+    const bitrateA = a.bitrate ?? Number.POSITIVE_INFINITY;
+    const bitrateB = b.bitrate ?? Number.POSITIVE_INFINITY;
+
+    if (prioritizeEfficiency) {
+      if (widthA !== widthB) return widthA - widthB;
+      if (bitrateA !== bitrateB) return bitrateA - bitrateB;
+      return 0;
+    }
+
+    const diffA = Math.abs(widthA - targetWidth);
+    const diffB = Math.abs(widthB - targetWidth);
+    if (diffA !== diffB) return diffA - diffB;
+    if (bitrateA !== bitrateB) return bitrateB - bitrateA;
+    return widthB - widthA;
   });
+};
+
+const pickDefaultTrack = (request: NextRequest, tracks: TrackManifest[]): Track => {
+  const hintedScheme = request.headers.get('sec-ch-prefers-color-scheme');
+  const fallback: Track = 'day';
+  if (!hintedScheme) return tracks.find(t => t.id === fallback)?.id ?? fallback;
+  const scheme = hintedScheme.toLowerCase();
+  if (scheme.includes('dark')) {
+    return tracks.find(t => t.id === 'night')?.id ?? fallback;
+  }
+  if (scheme.includes('light')) {
+    return tracks.find(t => t.id === 'day')?.id ?? fallback;
+  }
+  return tracks.find(t => t.id === fallback)?.id ?? fallback;
+};
+
+export async function GET(request: NextRequest) {
+  const targetWidth = deriveTargetWidth(request);
+  const efficient = prefersLowBandwidth(request);
+
+  const availableTracks = TRACK_LIBRARY.map(track => {
+    const video = sortVariants(filterExistingSources(track.video), targetWidth, efficient);
+    const audio = track.audio ? filterExistingSources(track.audio) : undefined;
+    return { ...track, video, audio } satisfies TrackManifest;
+  }).filter(track => track.video.length > 0 || (track.audio && track.audio.length > 0));
+
+  const defaultTrack = pickDefaultTrack(request, availableTracks);
+
+  const manifest: PlaylistManifest = {
+    tracks: availableTracks,
+    defaultTrack,
+  };
+
+  return NextResponse.json(manifest);
 }

--- a/components/poetry/VerseCycler.tsx
+++ b/components/poetry/VerseCycler.tsx
@@ -39,7 +39,7 @@ export function VerseCycler() {
           <VerseBlock
             urdu={current.lang === 'ur' ? current.text : undefined}
             transliteration={current.transliteration}
-            translation={current.translation if current.translation else (current.lang === 'en' ? current.text : undefined)}
+            translation={current.translation ?? (current.lang === 'en' ? current.text : undefined)}
             showTransliteration={showTransliteration}
             showTranslation={showTranslation}
           />

--- a/components/ui/ControlsBar.tsx
+++ b/components/ui/ControlsBar.tsx
@@ -1,15 +1,23 @@
 'use client';
+import clsx from 'classnames';
 import { useSceneStore } from '@/lib/scene';
+import type { Track } from '@/lib/types';
 
 export function ControlsBar() {
   const focus = useSceneStore(s => s.focusMode);
   const toggleFocus = useSceneStore(s => s.toggleFocus);
   const track = useSceneStore(s => s.track);
-  const toggleTrack = useSceneStore(s => s.toggleTrack);
+  const setTrack = useSceneStore(s => s.setTrack);
+  const playlist = useSceneStore(s => s.playlist);
   const subtitles = useSceneStore(s => s.subtitles);
   const setSubtitles = useSceneStore(s => s.setSubtitles);
   const particleDensity = useSceneStore(s => s.particleDensity);
   const setParticleDensity = useSceneStore(s => s.setParticleDensity);
+
+  const availableTracks = playlist?.tracks ?? [];
+  const trackOptions = availableTracks.length
+    ? availableTracks.map(option => ({ id: option.id, label: option.label }))
+    : (['day', 'night'] satisfies Track[]).map(id => ({ id, label: id === 'day' ? 'Day' : 'Night' }));
 
   return (
     <div className="pointer-events-auto fixed inset-x-0 bottom-0 z-10 px-4 pb-4">
@@ -18,9 +26,25 @@ export function ControlsBar() {
           <button onClick={toggleFocus} className="rounded-xl border border-white/15 px-3 py-2 hover:bg-white/5">
             {focus ? 'Exit Focus' : 'Focus Mode'}
           </button>
-          <button onClick={toggleTrack} className="rounded-xl border border-white/15 px-3 py-2 hover:bg-white/5">
-            {track === 'day' ? 'Night' : 'Day'}
-          </button>
+          <div className="flex items-center gap-2">
+            <span className="text-white/60">Scene</span>
+            <div className="flex gap-2" role="group" aria-label="Scene selection">
+              {trackOptions.map(option => (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => (availableTracks.length ? setTrack(option.id) : setTrack(option.id))}
+                  className={clsx(
+                    'rounded-xl border border-white/15 px-3 py-2 transition-colors',
+                    track === option.id ? 'bg-white/20 text-white shadow-inner' : 'hover:bg-white/5 text-white/80',
+                  )}
+                  aria-pressed={track === option.id}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
           <label className="flex items-center gap-2">
             <input type="checkbox"
               checked={subtitles.transliteration}

--- a/components/video/EarthWindow.tsx
+++ b/components/video/EarthWindow.tsx
@@ -1,33 +1,141 @@
 'use client';
-import { motion, AnimatePresence } from 'framer-motion';
-import Image from 'next/image';
+
+import { useEffect, useMemo } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useSceneStore } from '@/lib/scene';
+import type { PlaylistManifest, TrackManifest } from '@/lib/types';
+import { syncTrackAudio } from '@/lib/audio';
+
+const logError = (...args: Parameters<typeof console.error>) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(...args);
+  }
+};
+
+const sourceType = (source: TrackManifest['video'][number]) =>
+  source.codec ? `${source.type}; codecs="${source.codec}"` : source.type;
+
+const pickTrack = (playlist: PlaylistManifest | undefined, trackId: TrackManifest['id']) => {
+  if (!playlist) return undefined;
+  return playlist.tracks.find(entry => entry.id === trackId);
+};
+
+const preloadPoster = (poster: string) => {
+  if (typeof window === 'undefined') return;
+  const image = new window.Image();
+  image.src = poster;
+};
 
 export function EarthWindow() {
   const track = useSceneStore(s => s.track);
+  const playlist = useSceneStore(s => s.playlist);
+  const setPlaylist = useSceneStore(s => s.setPlaylist);
+
+  useEffect(() => {
+    if (playlist) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetch('/api/playlist', { cache: 'no-store' });
+        if (!response.ok) throw new Error(`Unexpected ${response.status}`);
+        const manifest = (await response.json()) as PlaylistManifest;
+        if (!cancelled) {
+          setPlaylist(manifest);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          logError('Failed to load playlist manifest', error);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [playlist, setPlaylist]);
+
+  const fallbackTrack = useMemo<TrackManifest>(
+    () => ({
+      id: track,
+      label: track === 'day' ? 'Day' : 'Night',
+      poster: `/images/poster_${track}.jpg`,
+      loop: true,
+      video: [
+        {
+          url: `/video/earth_${track}_1080.mp4`,
+          type: 'video/mp4',
+          width: 1920,
+          height: 1080,
+        },
+        {
+          url: `/video/earth_${track}_1080.mp4#720p`,
+          type: 'video/mp4',
+          width: 1280,
+          height: 720,
+        },
+      ],
+    }),
+    [track],
+  );
+
+  const activeTrack = useMemo(
+    () => pickTrack(playlist, track) ?? fallbackTrack,
+    [fallbackTrack, playlist, track],
+  );
+
+  useEffect(() => {
+    const pool = playlist?.tracks ?? [];
+    if (!pool.length) return;
+    const nextTrack = pool.find(entry => entry.id !== track);
+    if (nextTrack) {
+      preloadPoster(nextTrack.poster);
+    }
+  }, [playlist, track]);
+
+  useEffect(() => {
+    void syncTrackAudio(activeTrack);
+  }, [activeTrack]);
+
+  const orderedSources = useMemo(() => {
+    if (!activeTrack) return [];
+    if (typeof window === 'undefined') return activeTrack.video;
+    const dpr = window.devicePixelRatio || 1;
+    const viewportWidth = window.innerWidth * dpr;
+    return [...activeTrack.video].sort((a, b) => {
+      const widthA = a.width ?? viewportWidth;
+      const widthB = b.width ?? viewportWidth;
+      const diffA = Math.abs(widthA - viewportWidth);
+      const diffB = Math.abs(widthB - viewportWidth);
+      if (diffA !== diffB) return diffA - diffB;
+      const bitrateA = a.bitrate ?? Number.POSITIVE_INFINITY;
+      const bitrateB = b.bitrate ?? Number.POSITIVE_INFINITY;
+      if (bitrateA !== bitrateB) return bitrateB - bitrateA;
+      return widthB - widthA;
+    });
+  }, [activeTrack]);
+
   return (
-    <div className="absolute inset-0 -z-10">
-      <video
-        key={track}
-        className="h-full w-full object-cover"
-        poster={`/images/poster_${track}.jpg`}
-        autoPlay
-        muted
-        loop
-        playsInline
-      >
-        <source src={`/video/earth_${track}_1080.mp4`} type="video/mp4" />
-        <source src={`/video/earth_${track}.webm`} type="video/webm" />
-      </video>
+    <div className="absolute inset-0 -z-10 overflow-hidden">
       <AnimatePresence mode="wait">
-        <motion.div
-          key={track + "_fade"}
-          initial={{ opacity: 1 }}
-          animate={{ opacity: 0 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.8 }}
-          className="absolute inset-0 bg-black"
-        />
+        {activeTrack ? (
+          <motion.video
+            key={activeTrack.id}
+            className="h-full w-full object-cover"
+            poster={activeTrack.poster}
+            autoPlay
+            muted
+            loop={activeTrack.loop !== false}
+            playsInline
+            preload="auto"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 1.1 }}
+          >
+            {orderedSources.map(source => (
+              <source key={source.url} src={source.url} type={sourceType(source)} />
+            ))}
+          </motion.video>
+        ) : null}
       </AnimatePresence>
     </div>
   );

--- a/lib/audio.ts
+++ b/lib/audio.ts
@@ -1,7 +1,233 @@
 'use client';
-let _enabled = false;
-let _volume = 0.6;
-export function initAudio() { _enabled = true; }
-export function setVolume(v: number) { _volume = Math.max(0, Math.min(1, v)); }
-export function isAudioEnabled() { return _enabled; }
-export function energy() { return 0; } // replace with AnalyserNode RMS later
+
+import type { MediaSource, TrackManifest } from './types';
+
+type Channel = {
+  element?: HTMLAudioElement;
+  source?: MediaElementAudioSourceNode;
+  gain?: GainNode;
+  trackId?: TrackManifest['id'];
+};
+
+const channels: [Channel, Channel] = [{}, {}];
+let audioContext: AudioContext | null = null;
+let analyser: AnalyserNode | null = null;
+let masterGain: GainNode | null = null;
+let enabled = false;
+let volume = 0.6;
+let activeChannelIndex = 0;
+let energyValue = 0;
+let energyBuffer: Uint8Array | null = null;
+let energyRaf: number | null = null;
+
+const CROSS_FADE_SECONDS = 1.4;
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const debugWarn = (...args: Parameters<typeof console.warn>) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(...args);
+  }
+};
+
+const ensureContext = () => {
+  if (typeof window === 'undefined') return;
+  if (audioContext) return;
+  const audioWindow = window as typeof window & { webkitAudioContext?: typeof AudioContext };
+  const ContextCtor = audioWindow.AudioContext ?? audioWindow.webkitAudioContext;
+  if (!ContextCtor) return;
+  audioContext = new ContextCtor();
+  masterGain = audioContext.createGain();
+  masterGain.gain.value = volume;
+  analyser = audioContext.createAnalyser();
+  analyser.fftSize = 256;
+  masterGain.connect(analyser);
+  analyser.connect(audioContext.destination);
+  energyBuffer = new Uint8Array(analyser.frequencyBinCount);
+  startEnergyLoop();
+};
+
+const startEnergyLoop = () => {
+  if (!analyser || !energyBuffer || energyRaf !== null || typeof window === 'undefined') return;
+  const step = () => {
+    if (!analyser || !energyBuffer) {
+      energyRaf = null;
+      return;
+    }
+    analyser.getByteFrequencyData(energyBuffer);
+    let sum = 0;
+    for (let i = 0; i < energyBuffer.length; i += 1) {
+      sum += energyBuffer[i];
+    }
+    const average = energyBuffer.length ? sum / energyBuffer.length : 0;
+    energyValue = average / 255;
+    energyRaf = window.requestAnimationFrame(step);
+  };
+  energyRaf = window.requestAnimationFrame(step);
+};
+
+const getChannel = (index: number): Channel => {
+  const channel = channels[index];
+  if (typeof window !== 'undefined' && !channel.element) {
+    channel.element = new Audio();
+    channel.element.loop = true;
+    channel.element.preload = 'auto';
+    channel.element.crossOrigin = 'anonymous';
+    channel.element.volume = volume;
+  }
+  if (channel.element && audioContext && masterGain && !channel.source) {
+    channel.source = audioContext.createMediaElementSource(channel.element);
+    channel.gain = audioContext.createGain();
+    channel.gain.gain.value = channel.element.paused ? 0 : 1;
+    channel.source.connect(channel.gain);
+    channel.gain.connect(masterGain);
+    channel.element.volume = 1;
+  }
+  return channel;
+};
+
+const stopChannel = (channel: Channel) => {
+  if (!channel.element) return;
+  if (channel.gain && audioContext) {
+    const now = audioContext.currentTime;
+    channel.gain.gain.cancelScheduledValues(now);
+    channel.gain.gain.setValueAtTime(0, now);
+  }
+  channel.element.pause();
+};
+
+const animateGain = (channel: Channel, target: number, duration: number) => {
+  const channelElement = channel.element;
+  if (channel.gain && audioContext) {
+    const now = audioContext.currentTime;
+    channel.gain.gain.cancelScheduledValues(now);
+    channel.gain.gain.setValueAtTime(channel.gain.gain.value, now);
+    channel.gain.gain.linearRampToValueAtTime(target, now + duration);
+    return;
+  }
+  if (!channelElement || typeof window === 'undefined') return;
+  const startVolume = channelElement.volume;
+  const targetVolume = target * volume;
+  const startTime = performance.now();
+  const tick = (time: number) => {
+    const progress = clamp((time - startTime) / (duration * 1000), 0, 1);
+    channelElement.volume = startVolume + (targetVolume - startVolume) * progress;
+    if (progress < 1) {
+      window.requestAnimationFrame(tick);
+    } else if (targetVolume === 0) {
+      channelElement.pause();
+    }
+  };
+  window.requestAnimationFrame(tick);
+};
+
+const canPlaySource = (candidate: MediaSource): boolean => {
+  if (typeof document === 'undefined') return true;
+  const testElement = document.createElement('audio');
+  const type = candidate.codec ? `${candidate.type}; codecs="${candidate.codec}"` : candidate.type;
+  if (!type) return true;
+  return testElement.canPlayType(type) !== '';
+};
+
+const selectAudioSource = (track: TrackManifest): MediaSource | undefined => {
+  if (!track.audio || track.audio.length === 0) return undefined;
+  const supported = track.audio.find(canPlaySource);
+  return supported ?? track.audio[0];
+};
+
+export async function initAudio() {
+  ensureContext();
+  enabled = true;
+  if (audioContext?.state === 'suspended') {
+    try {
+      await audioContext.resume();
+    } catch (err) {
+      debugWarn('Unable to resume audio context', err);
+    }
+  }
+}
+
+export function setVolume(next: number) {
+  volume = clamp(next, 0, 1);
+  if (masterGain) {
+    masterGain.gain.value = volume;
+  } else {
+    channels.forEach((channel, index) => {
+      if (channel.element && !channel.gain) {
+        const isActive = index === activeChannelIndex;
+        channel.element.volume = (isActive ? 1 : 0) * volume;
+      }
+    });
+  }
+}
+
+export function isAudioEnabled() {
+  return enabled;
+}
+
+export function energy() {
+  return energyValue;
+}
+
+const pauseAfterFade = (channel: Channel, duration: number) => {
+  if (!channel.element || typeof window === 'undefined') return;
+  window.setTimeout(() => {
+    if (!channel.element) return;
+    if (channel.gain) {
+      // When using Web Audio we leave the element playing silently.
+      return;
+    }
+    if (channel.element.volume === 0) {
+      channel.element.pause();
+    }
+  }, duration * 1000 + 120);
+};
+
+export async function syncTrackAudio(track?: TrackManifest) {
+  if (!track || !track.audio || track.audio.length === 0) {
+    const current = getChannel(activeChannelIndex);
+    animateGain(current, 0, CROSS_FADE_SECONDS / 2);
+    pauseAfterFade(current, CROSS_FADE_SECONDS / 2);
+    return;
+  }
+
+  ensureContext();
+  const nextIndex = 1 - activeChannelIndex;
+  const nextChannel = getChannel(nextIndex);
+  const currentChannel = getChannel(activeChannelIndex);
+  const audioSource = selectAudioSource(track);
+
+  if (!audioSource || !nextChannel.element) return;
+
+  if (nextChannel.element.src !== audioSource.url) {
+    nextChannel.element.src = audioSource.url;
+  }
+  nextChannel.element.loop = track.loop ?? true;
+
+  try {
+    await nextChannel.element.play();
+  } catch (err) {
+    // Autoplay policies might block playback until the user interacts with the page.
+    debugWarn('Audio playback blocked until user interaction', err);
+  }
+
+  if (enabled && audioContext?.state === 'suspended') {
+    try {
+      await audioContext.resume();
+    } catch (err) {
+      debugWarn('Unable to resume suspended audio context', err);
+    }
+  }
+
+  animateGain(nextChannel, 1, CROSS_FADE_SECONDS);
+  animateGain(currentChannel, 0, CROSS_FADE_SECONDS);
+  pauseAfterFade(currentChannel, CROSS_FADE_SECONDS);
+
+  nextChannel.trackId = track.id;
+  activeChannelIndex = nextIndex;
+}
+
+export function stopAudio() {
+  channels.forEach(stopChannel);
+  activeChannelIndex = 0;
+}

--- a/lib/scene.ts
+++ b/lib/scene.ts
@@ -1,11 +1,13 @@
 'use client';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { Track } from './types';
+import type { PlaylistManifest, Track } from './types';
+import { energy as audioEnergy } from './audio';
 
 type Subtitles = { transliteration: boolean; translation: boolean };
 
 type State = {
+  playlist?: PlaylistManifest;
   track: Track;
   focusMode: boolean;
   subtitles: Subtitles;
@@ -13,6 +15,8 @@ type State = {
   verseIntervalMs: number;
   particleDensity: number;
   energy: () => number;
+  setTrack: (track: Track) => void;
+  setPlaylist: (playlist: PlaylistManifest) => void;
   toggleTrack: () => void;
   toggleFocus: () => void;
   nextVerse: () => void;
@@ -20,17 +24,51 @@ type State = {
   setParticleDensity: (v: number) => void;
 };
 
-export const useSceneStore = create<State>()(persist((set, get) => ({
+export const useSceneStore = create<State>()(persist((set) => ({
+  playlist: undefined,
   track: 'day',
   focusMode: false,
   subtitles: { transliteration: false, translation: true },
   verseIndex: 0,
   verseIntervalMs: Number(process.env.NEXT_PUBLIC_VERSE_INTERVAL_MS ?? 18000),
   particleDensity: Number(process.env.NEXT_PUBLIC_PARTICLE_DENSITY ?? 0.8),
-  energy: () => 0, // placeholder for audio-reactive energy
-  toggleTrack: () => set(s => ({ track: s.track === 'day' ? 'night' : 'day' })),
+  energy: () => audioEnergy(),
+  setTrack: (track) => set({ track }),
+  setPlaylist: (playlist) => set(state => {
+    const hasCurrent = playlist.tracks.some(entry => entry.id === state.track);
+    return {
+      playlist,
+      track: hasCurrent ? state.track : playlist.defaultTrack,
+    };
+  }),
+  toggleTrack: () => set(state => {
+    const available = state.playlist?.tracks;
+    if (!available || available.length === 0) {
+      return { track: state.track === 'day' ? 'night' : 'day' };
+    }
+    const currentIndex = available.findIndex(entry => entry.id === state.track);
+    const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % available.length : 0;
+    return { track: available[nextIndex]?.id ?? state.track };
+  }),
   toggleFocus: () => set(s => ({ focusMode: !s.focusMode })),
   nextVerse: () => set(s => ({ verseIndex: s.verseIndex + 1 })),
   setSubtitles: (subtitles) => set({ subtitles }),
   setParticleDensity: (v) => set({ particleDensity: v }),
-}), { name: 'earth-ghazal' }));
+}), {
+  name: 'earth-ghazal',
+  partialize: ({
+    track,
+    focusMode,
+    subtitles,
+    verseIndex,
+    verseIntervalMs,
+    particleDensity,
+  }) => ({
+    track,
+    focusMode,
+    subtitles,
+    verseIndex,
+    verseIntervalMs,
+    particleDensity,
+  }),
+}));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,9 +9,26 @@ export type Verse = {
   displayMs?: number;
 };
 export type Track = 'day' | 'night';
-export type Playlist = {
-  track: Track;
-  srcs: { type: 'mp4' | 'webm'; url: string }[];
+
+export type MediaSource = {
+  url: string;
+  type: string;
+  codec?: string;
+  width?: number;
+  height?: number;
+  bitrate?: number;
+};
+
+export type TrackManifest = {
+  id: Track;
+  label: string;
   poster: string;
-  loop: boolean;
+  loop?: boolean;
+  video: MediaSource[];
+  audio?: MediaSource[];
+};
+
+export type PlaylistManifest = {
+  tracks: TrackManifest[];
+  defaultTrack: Track;
 };


### PR DESCRIPTION
## Summary
- extend the playlist API to deliver multi-variant day and night manifests that respond to client hints
- overhaul the media playback stack to fetch manifests, persist track selection, and crossfade video/audio while preloading assets
- refresh the controls and verse cycler to reflect selected tracks and fix translation fallback handling, and add an ESLint config for repeatable linting

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68cb053c38688332b7127e97ef6eb147